### PR TITLE
Correct function and signature to refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ token_type: Bearer
 
 If the token is expired, one can use
 ```python
-qtrade.refresh_token()
+qtrade.refresh_access_token(from_yaml=True)
 ```
-to refresh the access token using the saved refresh token.
+to refresh the access token using the saved refresh token. 
 
 Once the tokens are set correctly, I have currently added methods to get ticker quotes, the
 current status of all positions in any Questrade account that is associated with the tokens,


### PR DESCRIPTION
The README.md mentions the existence of a .refresh_token function but none by that name can be found. Therefore I replaced it with refresh_access_token. Also, as the example mentions using the 'saved' refresh token I've added the from_yaml=True argument as this will get the yaml loaded/saved if token changed.